### PR TITLE
Fix build break when building with libpng and without libjpeg

### DIFF
--- a/src/ipa/xgd/device.h
+++ b/src/ipa/xgd/device.h
@@ -21,7 +21,7 @@
  */
 static void wmf_gd_device_open (wmfAPI* API)
 {	
-#ifndef HAVE_LIBPNG
+#if !defined(HAVE_LIBPNG) || !defined(HAVE_LIBJPEG)
 	wmf_gd_t* ddata = WMF_GD_GetData (API);
 #endif
 


### PR DESCRIPTION
Hello,

I ran into this issue when I was trying to build the library without libjpeg.
Local variable is protected by #ifndef , but only available when libpng is missing.
It should be available when either of libraries is missing.