### PR TITLE
Use pkg-config to detect freetype2.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -418,15 +418,10 @@ fi
 CPPFLAGS="$freetype_cflags $CPPFLAGS"
 LDFLAGS="$LDFLAGS $freetype_libs"
 
-AC_CHECK_LIB(freetype,FT_Init_FreeType,[
-	WMF_FT_LDFLAGS="$freetype_libs"
-],[	AC_MSG_ERROR([* * * freetype(2) is required * * *])
-])
-AC_CHECK_HEADER(ft2build.h,[
-	WMF_FT_CFLAGS="$freetype_cflags"
-	WMF_FT_CONFIG_CFLAGS="$freetype_cflags"
-],[	AC_MSG_ERROR([* * * freetype(2) is required * * *])
-])
+PKG_CHECK_MODULES(FT2, freetype2)
+WMF_FT_LDFLAGS=$FT2_LIBS
+WMF_FT_CFLAGS=$FT2_CFLAGS
+WMF_FT_CONFIG_CFLAGS=$FT2_CFLAGS
 
 GD_DEFS="$GD_DEFS -DHAVE_LIBFREETYPE"
 


### PR DESCRIPTION
- Other methods have been deprectated for a long time

This  break building on recent Freedesktop-sdk

Project needs an autoreconf.