### PR TITLE
Fix missing includes on macOS

### DIFF
--- a/src/extra/gd/gd.c
+++ b/src/extra/gd/gd.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <limits.h>
 #include <math.h>
 #include <string.h>
 #include <stdlib.h>

--- a/src/extra/gd/gd_gd2.c
+++ b/src/extra/gd/gd_gd2.c
@@ -12,6 +12,7 @@
 
 #include <stdio.h>
 #include <errno.h>
+#include <limits.h>
 #include <math.h>
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
`limits.h` for `INT_MAX` and `SHRT_MAX`