### PR TITLE
sizeof('c')=4, not 1: fix isExponentNegative expectedWidth accounting

### DIFF
--- a/src/extra/trio/trio.c
+++ b/src/extra/trio/trio.c
@@ -2222,7 +2222,7 @@ TrioWriteDouble(trio_T *self,
   if (exponentDigits > 0)
     expectedWidth += exponentDigits + sizeof("E+") - 1;
   if (isExponentNegative)
-    expectedWidth += sizeof('-') - 1;
+    expectedWidth += sizeof("-") - 1;
   if (isHex)
     expectedWidth += sizeof("0X") - 1;
   


### PR DESCRIPTION
The one above does it correctly:
  if (isNegative || (flags & FLAGS_SHOWSIGN))
    expectedWidth += sizeof("-") - 1;
(this is 2 - 1).

But
  if (isExponentNegative)
    expectedWidth += sizeof('-') - 1;
is 4 - 1. This probably isn't right.

As found by DCS `[^._]sizeof[ (]'.{1,2}' filetype:c`

Ref: https://paste.sr.ht/~nabijaczleweli/6ee9ccf301a2651afb693bff46e3671d3f7cdd89
Ref: https://101010.pl/@nabijaczleweli/111587138076843793