### PR TITLE
Fix font installation dir

### DIFF
--- a/fonts/Makefile.am
+++ b/fonts/Makefile.am
@@ -1,4 +1,4 @@
-fontdir = $(datadir)/libwmf/fonts/
+fontdir = @WMF_FONTDIR@
 
 bin_SCRIPTS = libwmf-fontmap
 


### PR DESCRIPTION
Fixes 56422489d51

If I understand the commit correctly this was meant to move the actual installation directory too.