### PR TITLE
Make distcheck work cleanly

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,7 @@ DIST_SUBDIRS = . src include fonts
 
 SUBDIRS = $(DIRHEAVY)
 
-bin_SCRIPTS = libwmf-config
+dist_bin_SCRIPTS = libwmf-config
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libwmf.pc

--- a/Makefile.am
+++ b/Makefile.am
@@ -36,5 +36,4 @@ WMFEXAMPLES = \
 
 EXTRA_DIST = AUTHORS BUILDING CREDITS NEWS README $(WMFEXAMPLES) \
 	libwmf.spec \
-	patches/acconfig.h \
-	ac-helpers/pkg-config/pkg.m4
+	patches/acconfig.h

--- a/configure.ac
+++ b/configure.ac
@@ -747,15 +747,6 @@ AC_SUBST(GDK_PIXBUF_DIR)
 
 dnl Other options...
 
-AC_ARG_WITH(docdir,[  --with-docdir=DIR       install documentation in DIR],[
-	WMF_DOCDIR=$withval
-],[	if test "x$prefix" = "xNONE"; then
-		WMF_DOCDIR=$ac_default_prefix/share/doc/$PACKAGE
-	else
-		WMF_DOCDIR=$prefix/share/doc/$PACKAGE
-	fi
-])
-
 AC_ARG_WITH(fontdir,[  --with-fontdir=DIR      install Type1 fonts in DIR],[
 	WMF_FONTDIR=$withval
 ],[	if test "x$prefix" = "xNONE"; then
@@ -850,7 +841,6 @@ AM_LDFLAGS="$AM_LDFLAGS $WMF_PLOT_LDFLAGS $WMF_GD_LDFLAGS $WMF_FT_LDFLAGS $WMF_X
 AM_LDFLAGS="$AM_LDFLAGS $WMF_JPEG_LDFLAGS $WMF_PNG_LDFLAGS $WMF_Z_LDFLAGS $SYS_LIBM"
 AC_SUBST([AM_LDFLAGS])
 
-AC_SUBST(WMF_DOCDIR)
 AC_SUBST(WMF_FONTDIR)
 AC_SUBST(WMF_SYS_FONTMAP)
 AC_SUBST(WMF_XTRA_FONTMAP)
@@ -862,10 +852,6 @@ AC_SUBST(GD_DEFS)
 
 AC_CONFIG_FILES([
 Makefile
-doc/Makefile
-doc/caolan/Makefile
-doc/caolan/pics/Makefile
-doc/html/Makefile
 fonts/Makefile
 fonts/libwmf-fontmap
 fonts/fontmap
@@ -888,7 +874,6 @@ echo "	Support for GD:			$libwmf_gd"
 echo "	Support for JPEG though GD:	$libwmf_gd_jpeg"
 echo "	Support for XML:		$libwmf_xml"
 echo ""
-echo "	Documentation directory:	$WMF_DOCDIR"
 echo "	Font directory:			$WMF_FONTDIR"
 echo "	System XML fontmap file:	$WMF_SYS_FONTMAP"
 echo "	Non-system XML fontmap file:	$WMF_XTRA_FONTMAP"

--- a/libwmf.pc.in
+++ b/libwmf.pc.in
@@ -6,5 +6,5 @@ includedir=@includedir@
 Name: libwmf
 Description: A library for reading and converting Windows MetaFile vector graphics (WMF)
 Version: @LIBWMF_VERSION@
-Libs: -lwmf -lwmflite @WMF_LIBFLAGS@
+Libs: -lwmf -lwmflite @AM_LDFLAGS@
 Cflags: @WMF_CONFIG_CFLAGS@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -56,7 +56,7 @@ else
 LIBGD = extra/gd/libgd.la
 endif
 
-libwmf_la_LIBADD = ipa/libipa.la libwmflite.la $(LIBGD) $(LIBTRIO) @WMF_LIBFLAGS@
+libwmf_la_LIBADD = ipa/libipa.la libwmflite.la $(LIBGD) $(LIBTRIO)
 
 libwmf_la_LDFLAGS = \
 	-no-undefined \


### PR DESCRIPTION
It would be great to have a new release with the fixes from e.g. #14 #15. Due to the removal of the committed copies of configure / Makefile.in, uploading `make distcheck` results to the new release would probably be a good idea. So I tried it out and hit a couple errors, but after this patch series `make distcheck` once again passes. A couple of these errors are pretty old...