### PR TITLE
Advertise natural pixbuf size in GdkPixbufModuleSizeFunc

### DIFF
--- a/src/io-wmf.c
+++ b/src/io-wmf.c
@@ -162,24 +162,20 @@ gdk_pixbuf__wmf_image_stop_load (gpointer data, GError **error)
 		goto _wmf_error;
 	}
 
-	/* find out how large the app wants the pixbuf to be
+	unsigned int uwidth, uheight;
+	err = wmf_display_size (API, &uwidth, &uheight, resolution_x, resolution_y);
+	width = uwidth;
+	height = uheight;
+	if (err != wmf_E_None || width <= 0 || height <= 0) {
+		g_set_error (error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_CORRUPT_IMAGE,
+			     "Couldn't determine image size");
+		goto _wmf_error;
+	}
+
+	/* advertise natural size and find out how large the app wants the pixbuf to be
 	 */
 	if (context->size_func != NULL)
 		(*context->size_func) (&width, &height, context->user_data);
-
-	/* if these are <= 0, assume user wants the natural size of the wmf
-	 */
-	if (width <= 0 || height <= 0) {
-		unsigned int uwidth, uheight;
-		err = wmf_display_size (API, &uwidth, &uheight, resolution_x, resolution_y);
-		width = uwidth;
-		height = uheight;
-		if (err != wmf_E_None || width <= 0 || height <= 0) {
-			g_set_error (error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_CORRUPT_IMAGE,
-				     "Couldn't determine image size");
-			goto _wmf_error;
-		}
-	}
 
 	ddata->bbox          = bbox;        
 	ddata->width         = width;

--- a/src/io-wmf.c
+++ b/src/io-wmf.c
@@ -177,6 +177,14 @@ gdk_pixbuf__wmf_image_stop_load (gpointer data, GError **error)
 	if (context->size_func != NULL)
 		(*context->size_func) (&width, &height, context->user_data);
 
+	/* if these are <= 0, assume user wants to close, as specified in
+	 * GdkPixbufModuleSizeFunc documentation
+	 */
+	if (width <= 0 || height <= 0) {
+		result = TRUE;
+		goto _wmf_error;
+	}
+
 	ddata->bbox          = bbox;        
 	ddata->width         = width;
 	ddata->height        = height;


### PR DESCRIPTION
So that clients can know it as expected in a
GdkPixbufLoader::size-prepared signal handler, in which they can call gdk_pixbuf_loader_set_size() to modify the size.

Related: https://github.com/flathub/org.xfce.ristretto/issues/169