### PR TITLE
src: Include missing io.h header

### DIFF
--- a/src/extra/gd/gdft.c
+++ b/src/extra/gd/gdft.c
@@ -15,6 +15,7 @@
 #ifndef _WIN32
 #include <unistd.h>
 #else
+#include <io.h>
 #define R_OK 2
 #endif
 


### PR DESCRIPTION
This fixes a regression on Windows building introduced by #22