### PR TITLE
include: Export symbols from libwmf too

### DIFF
--- a/include/libwmf/api.h
+++ b/include/libwmf/api.h
@@ -20,6 +20,16 @@
 #ifndef LIBWMF_API_H
 #define LIBWMF_API_H
 
+#ifdef _WIN32
+  #ifdef LIBWMF_EXPORTS
+    #define LIBWMF_EXPORT __declspec(dllexport)
+  #else
+    #define LIBWMF_EXPORT __declspec(dllimport)
+  #endif
+#else
+  #define LIBWMF_EXPORT
+#endif
+
 #include <zlib.h>
 
 #include <libwmf/types.h>
@@ -41,12 +51,12 @@ extern wmf_error_t wmf_api_destroy (wmfAPI*);
 /**
  * Initializes library - 'lite' interface only
  */
-extern wmf_error_t wmf_lite_create (wmfAPI**,unsigned long,wmfAPI_Options*);
+extern LIBWMF_EXPORT wmf_error_t wmf_lite_create (wmfAPI**,unsigned long,wmfAPI_Options*);
 
 /**
  * Possibly completes output, and otherwise frees all allocated memory - 'lite' interface only
  */
-extern wmf_error_t wmf_lite_destroy (wmfAPI*);
+extern LIBWMF_EXPORT wmf_error_t wmf_lite_destroy (wmfAPI*);
 
 /**
  * Reads the header of the current metafile
@@ -56,22 +66,22 @@ extern wmf_error_t wmf_header_read (wmfAPI*);
 /**
  * Scans the current metafile to determine bounding box and resources
  */
-extern wmf_error_t wmf_scan (wmfAPI*,unsigned long,wmfD_Rect*);
+extern LIBWMF_EXPORT wmf_error_t wmf_scan (wmfAPI*,unsigned long,wmfD_Rect*);
 
 /**
  * Plays the current metafile, calling exporter graphics procedures
  */
-extern wmf_error_t wmf_play (wmfAPI*,unsigned long,wmfD_Rect*);
+extern LIBWMF_EXPORT wmf_error_t wmf_play (wmfAPI*,unsigned long,wmfD_Rect*);
 
 /**
  * Supplies a width and height for the current metafile
  */
-extern wmf_error_t wmf_size (wmfAPI*,float*,float*);
+extern LIBWMF_EXPORT wmf_error_t wmf_size (wmfAPI*,float*,float*);
 
 /**
  * Supplies a display (integer-) width and height for the current metafile
  */
-extern wmf_error_t wmf_display_size (wmfAPI*,unsigned int*,unsigned int*,double,double);
+extern LIBWMF_EXPORT wmf_error_t wmf_display_size (wmfAPI*,unsigned int*,unsigned int*,double,double);
 
 /**
  * Sets user defines input stream functions for reading a metafile
@@ -81,7 +91,7 @@ extern wmf_error_t wmf_bbuf_input (wmfAPI*,wmfRead,wmfSeek,wmfTell,void*);
 /**
  * Opens a file as the current metafile
  */
-extern wmf_error_t wmf_file_open (wmfAPI*,const char*);
+extern LIBWMF_EXPORT wmf_error_t wmf_file_open (wmfAPI*,const char*);
 
 /**
  * Closes the file corresponding to the current metafile
@@ -91,12 +101,12 @@ extern wmf_error_t wmf_file_close (wmfAPI*);
 /**
  * Specifies an array of unsigned char as the current metafile
  */
-extern wmf_error_t wmf_mem_open (wmfAPI*,unsigned char*,long);
+extern LIBWMF_EXPORT wmf_error_t wmf_mem_open (wmfAPI*,unsigned char*,long);
 
 /**
  * Disassociates array corresponding to the current metafile
  */
-extern wmf_error_t wmf_mem_close (wmfAPI*);
+extern LIBWMF_EXPORT wmf_error_t wmf_mem_close (wmfAPI*);
 
 /* wmf_stream_create: set FILE stream to 0 to write to memory;
  * wmf_stream_destroy: returns pointer to memory, if not a FILE stream
@@ -130,22 +140,22 @@ extern int wmf_stream_printf (wmfAPI*,wmfStream*,char*,...);
 /**
  * malloc() & attach to library's memory manager
  */
-extern void* wmf_malloc (wmfAPI*,size_t);
+extern LIBWMF_EXPORT void* wmf_malloc (wmfAPI*,size_t);
 
 /**
  * calloc() & attach to library's memory manager
  */
-extern void* wmf_calloc (wmfAPI*,size_t,size_t);
+extern LIBWMF_EXPORT void* wmf_calloc (wmfAPI*,size_t,size_t);
 
 /**
  * realloc() memory attached to library's memory manager
  */
-extern void* wmf_realloc (wmfAPI*,void*,size_t);
+extern LIBWMF_EXPORT void* wmf_realloc (wmfAPI*,void*,size_t);
 
 /**
  * free() memory attached to library's memory manager
  */
-extern void wmf_free (wmfAPI*,void*);
+extern LIBWMF_EXPORT void wmf_free (wmfAPI*,void*);
 
 /**
  * Detach memory from library's memory manager
@@ -155,22 +165,22 @@ extern void  wmf_detach (wmfAPI*,void*);
 /**
  * strdup() & attach to library's memory manager
  */
-extern char* wmf_strdup (wmfAPI*,const char*);
+extern LIBWMF_EXPORT char* wmf_strdup (wmfAPI*,const char*);
 
 /**
  * create concatenation of two strings and attach to library's memory manager
  */
-extern char* wmf_str_append (wmfAPI*,char*,char*);
+extern LIBWMF_EXPORT char* wmf_str_append (wmfAPI*,char*,char*);
 
 /**
  * strstr()
  */
-extern char* wmf_strstr (const char*,const char*);
+extern LIBWMF_EXPORT char* wmf_strstr (const char*,const char*);
 
 /**
  * Increases size of API's string buffer; returns new size or 0 on error
  */
-extern unsigned long wmf_strbuf_grow (wmfAPI*);
+extern LIBWMF_EXPORT unsigned long wmf_strbuf_grow (wmfAPI*);
 
 /**
  * Initializes the metafile player (called by wmf_api_create())
@@ -247,7 +257,7 @@ extern int wmf_stream_reset (void*);
 /**
  * Writes message to error stream (use WMF_ERROR macro)
  */
-extern void wmf_error (wmfAPI*,char*,int,char*);
+extern LIBWMF_EXPORT void wmf_error (wmfAPI*,char*,int,char*);
 
 /**
  * Writes message to debug stream (use WMF_DEBUG macro)
@@ -257,7 +267,7 @@ extern void wmf_debug (wmfAPI*,char*,int,char*);
 /**
  * Formatted print to debug stream
  */
-extern void wmf_printf (wmfAPI*,char*,...);
+extern LIBWMF_EXPORT void wmf_printf (wmfAPI*,char*,...);
 
 /**
  * Asserts on zero expression (use WMF_ASSERT macro)
@@ -277,7 +287,7 @@ extern void wmf_set_viewport_origin (wmfAPI*,wmfD_Coord);
 /**
  * Sets call-back function, called after every metafile record
  */
-extern void wmf_status_function (wmfAPI*,void*,wmfStatus);
+extern LIBWMF_EXPORT void wmf_status_function (wmfAPI*,void*,wmfStatus);
 
 /**
  * Writes to --wmf-write file (which may be WMF or home-made wmfxml)
@@ -288,17 +298,17 @@ extern void wmf_write (wmfAPI*,unsigned long,unsigned int,const char*,
 /**
  * Open --wmf-write file (which may be WMF or home-made wmfxml)
  */
-extern void wmf_write_begin (wmfAPI*,const char*);
+extern LIBWMF_EXPORT void wmf_write_begin (wmfAPI*,const char*);
 
 /**
  * Close --wmf-write file (which may be WMF or home-made wmfxml)
  */
-extern void wmf_write_end (wmfAPI*);
+extern LIBWMF_EXPORT void wmf_write_end (wmfAPI*);
 
 /**
  * Initialize a wmfAttributes structure
  */
-extern void wmf_attr_new (wmfAPI*,wmfAttributes*);
+extern LIBWMF_EXPORT void wmf_attr_new (wmfAPI*,wmfAttributes*);
 
 /**
  * Clear/Empty a wmfAttributes structure
@@ -308,12 +318,12 @@ extern void wmf_attr_clear (wmfAPI*,wmfAttributes*);
 /**
  * Free memory associated with a wmfAttributes structure
  */
-extern void wmf_attr_free (wmfAPI*,wmfAttributes*);
+extern LIBWMF_EXPORT void wmf_attr_free (wmfAPI*,wmfAttributes*);
 
 /**
  * Add an name&value to a wmfAttributes structure; returns ptr to value-in-list
  */
-extern const char * wmf_attr_add (wmfAPI*,wmfAttributes*,const char*,const char*);
+extern LIBWMF_EXPORT const char * wmf_attr_add (wmfAPI*,wmfAttributes*,const char*,const char*);
 
 /**
  * Return value of name in a wmfAttributes structure; returns 0 if name not found

--- a/include/libwmf/ipa.h
+++ b/include/libwmf/ipa.h
@@ -22,6 +22,16 @@
 #ifndef LIBWMF_IPA_H
 #define LIBWMF_IPA_H
 
+#ifdef _WIN32
+  #ifdef LIBWMF_EXPORTS
+    #define LIBWMF_EXPORT __declspec(dllexport)
+  #else
+    #define LIBWMF_EXPORT __declspec(dllimport)
+  #endif
+#else
+  #define LIBWMF_EXPORT
+#endif
+
 #include <libwmf/types.h>
 
 #ifdef __cplusplus
@@ -75,10 +85,10 @@ extern void   wmf_ipa_bmp_setcolor (wmfAPI*,wmfBMP*,wmfRGB*,unsigned char,unsign
 extern int    wmf_ipa_bmp_interpolate (wmfAPI*,wmfBMP*,wmfRGB*,float,float);
 
 extern void          wmf_ipa_color_init (wmfAPI*);
-extern void          wmf_ipa_color_add (wmfAPI*,wmfRGB*);
-extern unsigned long wmf_ipa_color_index (wmfAPI*,wmfRGB*);
-extern unsigned long wmf_ipa_color_count (wmfAPI*);
-extern wmfRGB*       wmf_ipa_color (wmfAPI*,unsigned long);
+extern LIBWMF_EXPORT void          wmf_ipa_color_add (wmfAPI*,wmfRGB*);
+extern LIBWMF_EXPORT unsigned long wmf_ipa_color_index (wmfAPI*,wmfRGB*);
+extern LIBWMF_EXPORT unsigned long wmf_ipa_color_count (wmfAPI*);
+extern LIBWMF_EXPORT wmfRGB*       wmf_ipa_color (wmfAPI*,unsigned long);
 
 extern char*        wmf_ipa_page_format (wmfAPI*,wmf_page_t);
 extern unsigned int wmf_ipa_page_width  (wmfAPI*,wmf_page_t);
@@ -88,7 +98,7 @@ extern unsigned int wmf_ipa_page_height (wmfAPI*,wmf_page_t);
  */
 extern wmfRGB wmf_rgb_white (void);
 extern wmfRGB wmf_rgb_black (void);
-extern wmfRGB wmf_rgb_color (wmfAPI*,float,float,float);
+extern LIBWMF_EXPORT wmfRGB wmf_rgb_color (wmfAPI*,float,float,float);
 
 /* Structure definitions
  */


### PR DESCRIPTION
This fixes a build error on MSYS2/MINGW since
the previous MR (#22) only took care of libwmflite.