### PR TITLE
include: Export symbols detected by MSYS2 grokker

### DIFF
--- a/include/libwmf/api.h
+++ b/include/libwmf/api.h
@@ -61,7 +61,7 @@ extern LIBWMF_EXPORT wmf_error_t wmf_lite_destroy (wmfAPI*);
 /**
  * Reads the header of the current metafile
  */
-extern wmf_error_t wmf_header_read (wmfAPI*);
+extern LIBWMF_EXPORT wmf_error_t wmf_header_read (wmfAPI*);
 
 /**
  * Scans the current metafile to determine bounding box and resources
@@ -86,7 +86,7 @@ extern LIBWMF_EXPORT wmf_error_t wmf_display_size (wmfAPI*,unsigned int*,unsigne
 /**
  * Sets user defines input stream functions for reading a metafile
  */
-extern wmf_error_t wmf_bbuf_input (wmfAPI*,wmfRead,wmfSeek,wmfTell,void*);
+extern LIBWMF_EXPORT wmf_error_t wmf_bbuf_input (wmfAPI*,wmfRead,wmfSeek,wmfTell,void*);
 
 /**
  * Opens a file as the current metafile
@@ -96,7 +96,7 @@ extern LIBWMF_EXPORT wmf_error_t wmf_file_open (wmfAPI*,const char*);
 /**
  * Closes the file corresponding to the current metafile
  */
-extern wmf_error_t wmf_file_close (wmfAPI*);
+extern LIBWMF_EXPORT wmf_error_t wmf_file_close (wmfAPI*);
 
 /**
  * Specifies an array of unsigned char as the current metafile
@@ -160,7 +160,7 @@ extern LIBWMF_EXPORT void wmf_free (wmfAPI*,void*);
 /**
  * Detach memory from library's memory manager
  */
-extern void  wmf_detach (wmfAPI*,void*);
+extern LIBWMF_EXPORT void  wmf_detach (wmfAPI*,void*);
 
 /**
  * strdup() & attach to library's memory manager
@@ -185,52 +185,52 @@ extern LIBWMF_EXPORT unsigned long wmf_strbuf_grow (wmfAPI*);
 /**
  * Initializes the metafile player (called by wmf_api_create())
  */
-extern wmf_error_t wmf_player_init (wmfAPI*);
+extern LIBWMF_EXPORT wmf_error_t wmf_player_init (wmfAPI*);
 
 /**
  * Returns the Aldus Checksum of the metafile's header
  */
-extern U16 wmf_aldus_checksum (wmfAPI*);
+extern LIBWMF_EXPORT U16 wmf_aldus_checksum (wmfAPI*);
 
 /**
  * Reads a two-byte sequence from the current metafile, returns U16
  */
-extern U16 wmf_read_16 (wmfAPI*);
+extern LIBWMF_EXPORT U16 wmf_read_16 (wmfAPI*);
 
 /**
  * Reads a four-byte sequence from the current metafile, returns U32
  */
-extern U32 wmf_read_32 (wmfAPI*,U16*,U16*);
+extern LIBWMF_EXPORT U32 wmf_read_32 (wmfAPI*,U16*,U16*);
 
 /**
  * file input (wmf_file_open): fgetc()
  */
-extern int wmf_file_read (void*);
+extern LIBWMF_EXPORT int wmf_file_read (void*);
 
 /**
  * file input (wmf_file_open): fseek()
  */
-extern int wmf_file_seek (void*,long);
+extern LIBWMF_EXPORT int wmf_file_seek (void*,long);
 
 /**
  * file input (wmf_file_open): ftell()
  */
-extern long wmf_file_tell (void*);
+extern LIBWMF_EXPORT long wmf_file_tell (void*);
 
 /**
  * memory input (wmf_mem_open): fgetc() equiv.
  */
-extern int wmf_mem_read (void*);
+extern LIBWMF_EXPORT int wmf_mem_read (void*);
 
 /**
  * memory input (wmf_mem_open): fseek() equiv.
  */
-extern int wmf_mem_seek (void*,long);
+extern LIBWMF_EXPORT int wmf_mem_seek (void*,long);
 
 /**
  * memory input (wmf_mem_open): ftell() equiv.
  */
-extern long wmf_mem_tell (void*);
+extern LIBWMF_EXPORT long wmf_mem_tell (void*);
 
 /* default ztream functions; NOT to be used directly! */
 
@@ -262,7 +262,7 @@ extern LIBWMF_EXPORT void wmf_error (wmfAPI*,char*,int,char*);
 /**
  * Writes message to debug stream (use WMF_DEBUG macro)
  */
-extern void wmf_debug (wmfAPI*,char*,int,char*);
+extern LIBWMF_EXPORT void wmf_debug (wmfAPI*,char*,int,char*);
 
 /**
  * Formatted print to debug stream
@@ -272,7 +272,7 @@ extern LIBWMF_EXPORT void wmf_printf (wmfAPI*,char*,...);
 /**
  * Asserts on zero expression (use WMF_ASSERT macro)
  */
-extern void wmf_assert (wmfAPI*,char*,int);
+extern LIBWMF_EXPORT void wmf_assert (wmfAPI*,char*,int);
 
 /**
  * Outputs library-specific command-line options
@@ -282,7 +282,7 @@ extern char* wmf_help (void);
 /**
  * Sets drawing origin in device coordinates
  */
-extern void wmf_set_viewport_origin (wmfAPI*,wmfD_Coord);
+extern LIBWMF_EXPORT void wmf_set_viewport_origin (wmfAPI*,wmfD_Coord);
 
 /**
  * Sets call-back function, called after every metafile record
@@ -292,7 +292,7 @@ extern LIBWMF_EXPORT void wmf_status_function (wmfAPI*,void*,wmfStatus);
 /**
  * Writes to --wmf-write file (which may be WMF or home-made wmfxml)
  */
-extern void wmf_write (wmfAPI*,unsigned long,unsigned int,const char*,
+extern LIBWMF_EXPORT void wmf_write (wmfAPI*,unsigned long,unsigned int,const char*,
 		       char**,const unsigned char*,unsigned long);
 
 /**
@@ -313,7 +313,7 @@ extern LIBWMF_EXPORT void wmf_attr_new (wmfAPI*,wmfAttributes*);
 /**
  * Clear/Empty a wmfAttributes structure
  */
-extern void wmf_attr_clear (wmfAPI*,wmfAttributes*);
+extern LIBWMF_EXPORT void wmf_attr_clear (wmfAPI*,wmfAttributes*);
 
 /**
  * Free memory associated with a wmfAttributes structure
@@ -328,7 +328,7 @@ extern LIBWMF_EXPORT const char * wmf_attr_add (wmfAPI*,wmfAttributes*,const cha
 /**
  * Return value of name in a wmfAttributes structure; returns 0 if name not found
  */
-extern const char * wmf_attr_query (wmfAPI*,wmfAttributes*,const char*);
+extern LIBWMF_EXPORT const char * wmf_attr_query (wmfAPI*,wmfAttributes*,const char*);
 
 /**
  * Load wmfxml file and wmf_mem_open() it

--- a/include/libwmf/canvas.h
+++ b/include/libwmf/canvas.h
@@ -33,63 +33,63 @@ typedef void * wmfCanvas;
 /**
  * Make a canvas for drawing to, to build a metafile in memory.
  */
-extern wmfCanvas * wmf_canvas (wmfAPI*,unsigned short,unsigned short,unsigned short);
+extern LIBWMF_EXPORT wmfCanvas * wmf_canvas (wmfAPI*,unsigned short,unsigned short,unsigned short);
 
 /**
  * Final canvas call: finish off the metafile, free canvas etc., and return the metafile buffer.
  */
-extern unsigned char * wmf_canvas_done (wmfAPI*,wmfCanvas*,unsigned char**,unsigned long*);
+extern LIBWMF_EXPORT unsigned char * wmf_canvas_done (wmfAPI*,wmfCanvas*,unsigned char**,unsigned long*);
 
 /**
  * Set current pen (stroke) attributes.
  */
-extern int wmf_canvas_set_pen (wmfAPI*,wmfCanvas*,
+extern LIBWMF_EXPORT int wmf_canvas_set_pen (wmfAPI*,wmfCanvas*,
 			       unsigned short,unsigned short,unsigned short,
 			       unsigned short,wmfRGB);
 
 /**
  * Set current brush (fill) attributes.
  */
-extern int wmf_canvas_set_brush (wmfAPI*,wmfCanvas*,unsigned short,unsigned short,wmfRGB);
+extern LIBWMF_EXPORT int wmf_canvas_set_brush (wmfAPI*,wmfCanvas*,unsigned short,unsigned short,wmfRGB);
 
 /**
  * Change current font.
  */
-extern int wmf_canvas_set_font (wmfAPI*,wmfCanvas*,const char*,
+extern LIBWMF_EXPORT int wmf_canvas_set_font (wmfAPI*,wmfCanvas*,const char*,
 				unsigned short,unsigned short,unsigned short,unsigned short,
 				unsigned short,unsigned short,unsigned short,unsigned short);
 
 /**
  * Set polygon fill mode.
  */
-extern int wmf_canvas_set_polyfill (wmfAPI*,wmfCanvas*,unsigned short);
+extern LIBWMF_EXPORT int wmf_canvas_set_polyfill (wmfAPI*,wmfCanvas*,unsigned short);
 
 /**
  * Set background mode.
  */
-extern int wmf_canvas_set_background (wmfAPI*,wmfCanvas*,unsigned short);
+extern LIBWMF_EXPORT int wmf_canvas_set_background (wmfAPI*,wmfCanvas*,unsigned short);
 
 /**
  * Set background color.
  */
-extern int wmf_canvas_set_bgcolor (wmfAPI*,wmfCanvas*,wmfRGB);
+extern LIBWMF_EXPORT int wmf_canvas_set_bgcolor (wmfAPI*,wmfCanvas*,wmfRGB);
 
 /**
  * Set text color.
  */
-extern int wmf_canvas_set_textcolor (wmfAPI*,wmfCanvas*,wmfRGB);
+extern LIBWMF_EXPORT int wmf_canvas_set_textcolor (wmfAPI*,wmfCanvas*,wmfRGB);
 
 /**
  * Draw a line.
  */
-extern int wmf_canvas_line (wmfAPI*,wmfCanvas*,
+extern LIBWMF_EXPORT int wmf_canvas_line (wmfAPI*,wmfCanvas*,
 			    unsigned short,unsigned short,
 			    unsigned short,unsigned short);
 
 /**
  * Draw a rounded rectangle.
  */
-extern int wmf_canvas_roundrect (wmfAPI*,wmfCanvas*,
+extern LIBWMF_EXPORT int wmf_canvas_roundrect (wmfAPI*,wmfCanvas*,
 				 unsigned short,unsigned short,
 				 unsigned short,unsigned short,
 				 unsigned short,unsigned short);
@@ -97,14 +97,14 @@ extern int wmf_canvas_roundrect (wmfAPI*,wmfCanvas*,
 /**
  * Draw a rectangle.
  */
-extern int wmf_canvas_rect (wmfAPI*,wmfCanvas*,
+extern LIBWMF_EXPORT int wmf_canvas_rect (wmfAPI*,wmfCanvas*,
 			    unsigned short,unsigned short,
 			    unsigned short,unsigned short);
 
 /**
  * Draw an ellipse in the given bounding box.
  */
-extern int wmf_canvas_ellipse (wmfAPI*,wmfCanvas*,
+extern LIBWMF_EXPORT int wmf_canvas_ellipse (wmfAPI*,wmfCanvas*,
 			       unsigned short,unsigned short,
 			       unsigned short,unsigned short);
 
@@ -121,7 +121,7 @@ typedef enum _wmf_canvas_arc_t
 /**
  * Draw an elliptic arc in the given bounding box.
  */
-extern int wmf_canvas_arc (wmfAPI*,wmfCanvas*,
+extern LIBWMF_EXPORT int wmf_canvas_arc (wmfAPI*,wmfCanvas*,
 			   unsigned short,unsigned short,
 			   unsigned short,unsigned short,
 			   unsigned short,unsigned short,
@@ -130,30 +130,30 @@ extern int wmf_canvas_arc (wmfAPI*,wmfCanvas*,
 /**
  * Draw a line connecting a sequence of points.
  */
-extern int wmf_canvas_polyline (wmfAPI*,wmfCanvas*,
+extern LIBWMF_EXPORT int wmf_canvas_polyline (wmfAPI*,wmfCanvas*,
 				unsigned short*,unsigned short*,unsigned short);
 
 /**
  * Draw a polygon.
  */
-extern int wmf_canvas_polygon (wmfAPI*,wmfCanvas*,
+extern LIBWMF_EXPORT int wmf_canvas_polygon (wmfAPI*,wmfCanvas*,
 			       unsigned short*,unsigned short*,unsigned short);
 
 /**
  * Draw a set of polygons.
  */
-extern int wmf_canvas_polygons (wmfAPI*,wmfCanvas*,unsigned short,
+extern LIBWMF_EXPORT int wmf_canvas_polygons (wmfAPI*,wmfCanvas*,unsigned short,
 				unsigned short**,unsigned short**,unsigned short*);
 
 /**
  * Draw text.
  */
-extern int wmf_canvas_text (wmfAPI*,wmfCanvas*,unsigned short,unsigned short,const char*);
+extern LIBWMF_EXPORT int wmf_canvas_text (wmfAPI*,wmfCanvas*,unsigned short,unsigned short,const char*);
 
 /**
  * Place a bitmap.
  */
-extern int wmf_canvas_bitmap (wmfAPI*,wmfCanvas*,unsigned short,unsigned short,
+extern LIBWMF_EXPORT int wmf_canvas_bitmap (wmfAPI*,wmfCanvas*,unsigned short,unsigned short,
 			      unsigned short,unsigned short,const unsigned char*,unsigned long);
 
 #ifdef __cplusplus

--- a/include/libwmf/ipa.h
+++ b/include/libwmf/ipa.h
@@ -84,7 +84,7 @@ extern int    wmf_ipa_bmp_color (wmfAPI*,wmfBMP*,wmfRGB*,unsigned int,unsigned i
 extern void   wmf_ipa_bmp_setcolor (wmfAPI*,wmfBMP*,wmfRGB*,unsigned char,unsigned int,unsigned int);
 extern int    wmf_ipa_bmp_interpolate (wmfAPI*,wmfBMP*,wmfRGB*,float,float);
 
-extern void          wmf_ipa_color_init (wmfAPI*);
+extern LIBWMF_EXPORT void          wmf_ipa_color_init (wmfAPI*);
 extern LIBWMF_EXPORT void          wmf_ipa_color_add (wmfAPI*,wmfRGB*);
 extern LIBWMF_EXPORT unsigned long wmf_ipa_color_index (wmfAPI*,wmfRGB*);
 extern LIBWMF_EXPORT unsigned long wmf_ipa_color_count (wmfAPI*);
@@ -96,8 +96,8 @@ extern unsigned int wmf_ipa_page_height (wmfAPI*,wmf_page_t);
 
 /* Other useful functions
  */
-extern wmfRGB wmf_rgb_white (void);
-extern wmfRGB wmf_rgb_black (void);
+extern LIBWMF_EXPORT wmfRGB wmf_rgb_white (void);
+extern LIBWMF_EXPORT wmfRGB wmf_rgb_black (void);
 extern LIBWMF_EXPORT wmfRGB wmf_rgb_color (wmfAPI*,float,float,float);
 
 /* Structure definitions


### PR DESCRIPTION
This MR is different from the previous (#22 and #25) since it does not fix a build failure.

It was created due to: https://github.com/msys2/MINGW-packages/pull/28831#issuecomment-4233712385

So, this MR needs to be double checked by the maintainer to confirm if such symbols should be exported.