### PR TITLE
Use public libgd APIs for system-gd builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -677,10 +677,8 @@ if [ test "$search_for_gd" != "no" ]; then
 	other_libs="$other_libs -lfreetype -lpng -lz $SYS_LIBM"
 
 	AC_CHECK_HEADER(gd.h,[
-		AC_CHECK_LIB(gd,gdClipSetAdd,[
-			AC_CHECK_LIB(gd,gdft_draw_bitmap,[
-				libwmf_gd="sys"
-			],,$other_libs)
+		AC_CHECK_LIB(gd,gdImageSetClip,[
+			libwmf_gd="sys"
 		],,$other_libs)
 	])
 fi
@@ -688,6 +686,9 @@ fi
 if [ test "x$libwmf_gd" != "xnone" ]; then
 	AC_DEFINE([HAVE_GD], [1], [Library gd is available])
 	build_gd_layer=yes
+	if [ test "x$libwmf_gd" = "xsys" ]; then
+		AC_DEFINE([HAVE_SYS_GD], [1], [Build against system libgd])
+	fi
 else
 	build_gd_layer=no
 fi
@@ -877,8 +878,11 @@ AC_SUBST([AM_CFLAGS])
 WMF_CONFIG_CFLAGS="$WMF_FT_CONFIG_CFLAGS $WMF_Z_CONFIG_CFLAGS $WMF_X_CONFIG_CFLAGS"
 AC_SUBST([WMF_CONFIG_CFLAGS])
 
-AM_LDFLAGS="$AM_LDFLAGS $WMF_PLOT_LDFLAGS $WMF_GD_LDFLAGS $WMF_FT_LDFLAGS $WMF_X_LDFLAGS $WMF_XML_LIBS"
-AM_LDFLAGS="$AM_LDFLAGS $WMF_JPEG_LDFLAGS $WMF_PNG_LDFLAGS $WMF_Z_LDFLAGS $SYS_LIBM"
+WMF_DEP_LIBS="$WMF_PLOT_LDFLAGS $WMF_GD_LDFLAGS $WMF_FT_LDFLAGS $WMF_X_LDFLAGS $WMF_XML_LIBS"
+WMF_DEP_LIBS="$WMF_DEP_LIBS $WMF_JPEG_LDFLAGS $WMF_PNG_LDFLAGS $WMF_Z_LDFLAGS $SYS_LIBM"
+AC_SUBST([WMF_DEP_LIBS])
+
+AM_LDFLAGS="$AM_LDFLAGS $WMF_DEP_LIBS"
 AC_SUBST([AM_LDFLAGS])
 
 AC_SUBST(WMF_FONTDIR)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -58,7 +58,7 @@ else
 LIBGD = extra/gd/libgd.la
 endif
 
-libwmf_la_LIBADD = ipa/libipa.la libwmflite.la $(LIBGD) $(LIBTRIO)
+libwmf_la_LIBADD = ipa/libipa.la libwmflite.la $(LIBGD) $(LIBTRIO) @WMF_DEP_LIBS@
 
 libwmf_la_LDFLAGS = \
 	-no-undefined \

--- a/src/ipa/xgd.c
+++ b/src/ipa/xgd.c
@@ -538,7 +538,36 @@ int * wmf_gd_image_pixels (void * gd_image)
 	int * pixels = 0;
 #ifdef HAVE_GD
 	gdImagePtr img = (gdImagePtr) gd_image;
-	if (img) pixels = img->_tpixels;
+	if (img)
+	{
+#ifdef HAVE_SYS_GD
+		static int* export_pixels = 0;
+		static size_t export_count = 0;
+
+		size_t width = gdImageSX (img);
+		size_t height = gdImageSY (img);
+		size_t count = width * height;
+		size_t row;
+		size_t col;
+
+		if (count > export_count)
+		{	int* more = (int*) realloc (export_pixels,count * sizeof (int));
+			if (more == 0) return (0);
+			export_pixels = more;
+			export_count = count;
+		}
+
+		for (row = 0; row < height; row++)
+		{	for (col = 0; col < width; col++)
+			{	export_pixels[(row * width) + col] = gdImageTrueColorPixel (img,col,row);
+			}
+		}
+
+		pixels = export_pixels;
+#else
+		pixels = img->_tpixels;
+#endif
+	}
 #endif /* HAVE_GD */
 	return (pixels);
 }

--- a/src/ipa/xgd.h
+++ b/src/ipa/xgd.h
@@ -27,9 +27,15 @@
 
 extern int gdImageBoundsSafe (gdImage*,int,int);
 
-extern void gdClipSetFree (gdImage*);
+#ifdef HAVE_SYS_GD
+static void wmf_gd_clip_reset (gdImage* image)
+{	gdImageSetClip (image,0,0,gdImageSX (image) - 1,gdImageSY (image) - 1);
+}
+#else
 extern void gdClipSetReset (gdImage*);
 extern void gdClipSetAdd (gdImage*,gdClipRectangle*);
+#define wmf_gd_clip_reset gdClipSetReset
+#endif
 
 typedef enum
 {	gd_arc_ellipse = 0,

--- a/src/ipa/xgd/device.h
+++ b/src/ipa/xgd/device.h
@@ -160,7 +160,7 @@ static void wmf_gd_device_end (wmfAPI* API)
 	if (gd->pen.image) gdImageDestroy (gd->pen.image);
 
 	if (ddata->type == wmf_gd_image)
-	{	gdClipSetReset (gd->image); /* Remove any clipping rectangles */
+	{	wmf_gd_clip_reset (gd->image); /* Remove any clipping rectangles */
 		ddata->gd_image = (void*) gd->image;
 	}
 	else

--- a/src/ipa/xgd/region.h
+++ b/src/ipa/xgd/region.h
@@ -98,13 +98,20 @@ static void wmf_gd_region_clip (wmfAPI* API,wmfPolyRectangle_t* poly_rect)
 	gdPoint TL;
 	gdPoint BR;
 
+#ifdef HAVE_SYS_GD
+	int x_min = 0;
+	int x_max = 0;
+	int y_min = 0;
+	int y_max = 0;
+#else
 	gdClipRectangle rect;
+#endif
 
 	unsigned int i;
 
 	WMF_DEBUG (API,"wmf_[gd_]region_clip");
 
-	gdClipSetReset (gd->image);
+	wmf_gd_clip_reset (gd->image);
 
 	if (poly_rect->count == 0) return;
 
@@ -112,11 +119,33 @@ static void wmf_gd_region_clip (wmfAPI* API,wmfPolyRectangle_t* poly_rect)
 	{	TL = gd_translate (API,poly_rect->TL[i]);
 		BR = gd_translate (API,poly_rect->BR[i]);
 
+#ifdef HAVE_SYS_GD
+		if (i == 0)
+		{	x_min = MIN (TL.x,BR.x);
+			x_max = MAX (TL.x,BR.x) - 1;
+			y_min = MIN (TL.y,BR.y);
+			y_max = MAX (TL.y,BR.y) - 1;
+			continue;
+		}
+
+		x_min = MIN (x_min,MIN (TL.x,BR.x));
+		x_max = MAX (x_max,MAX (TL.x,BR.x) - 1);
+		y_min = MIN (y_min,MIN (TL.y,BR.y));
+		y_max = MAX (y_max,MAX (TL.y,BR.y) - 1);
+#else
 		rect.x_min = MIN (TL.x,BR.x);
 		rect.x_max = MAX (TL.x,BR.x) - 1;
 		rect.y_min = MIN (TL.y,BR.y);
 		rect.y_max = MAX (TL.y,BR.y) - 1;
 
 		gdClipSetAdd (gd->image,&rect);
+#endif
 	}
+
+#ifdef HAVE_SYS_GD
+	/* libgd only supports a single clip rectangle, so collapse the WMF
+	 * region to its bounding box when building against system gd.
+	 */
+	gdImageSetClip (gd->image,x_min,y_min,x_max,y_max);
+#endif
 }


### PR DESCRIPTION
This makes `--with-sys-gd` work with current libgd instead of silently falling back to the embedded gd copy.

Changes:
- probe for the public `gdImageSetClip` API instead of the private `gdClipSetAdd` symbol
- define `HAVE_SYS_GD` and switch the xgd clipping helpers to public libgd APIs
- flatten exported GD image pixels for system libgd, which does not provide libwmf private `_tpixels` backing store
- link `libwmf.la` against the external libraries that bundled `libgd.la` used to pull in transitively

Context:
- Debian has longstanding embedded-libgd bugs open at #382511 and #635328
- this is the same embedded-copy concern discussed in #5

One behavioral note: libgd only exposes a single clip rectangle, so the system-gd path collapses multi-rectangle WMF clip regions to a bounding box. That keeps the system-gd build working with the public API while preserving the existing multi-rectangle behavior for the bundled fallback.

Validation on Debian unstable/arm64:
- `autoreconf -fiv`
- `./configure --with-sys-gd`
- `make -j1 V=1`
- `make -j1 V=1 check`

A macOS build would also be useful here, given the earlier issue discussion around macOS build problems.
