### PR TITLE
REGION_SubtractO() - In remaining minuend rectangles case use same co…

### DIFF
--- a/src/player/region.h
+++ b/src/player/region.h
@@ -850,7 +850,7 @@ static void REGION_SubtractO (
 				pNextRect++;
 			}
 			r1++;
-			left = r1->TL.x;
+			if (r1 != r1End) left = r1->TL.x;
 		}
 	}
 


### PR DESCRIPTION
These changes solve the previously reported heap overwrite bug as described in "Libwmf and Google's oss-fuzz" #18.
Adding the same safeguard as used for all of the other cases in the function causes the problem to go away.

This change should solve [OSS Fuzz 449762004](https://issues.oss-fuzz.com/issues/449762004).
