### PR TITLE
Add/move inclusions of <stdint.h> in order to provide missing SIZE_MAX

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 
 #include "wmfdefs.h"

--- a/src/player.c
+++ b/src/player.c
@@ -33,6 +33,7 @@
 #include "wmfdefs.h"
 #include "metadefs.h"
 
+#include <stdint.h>
 #include "player.h"
 #include "player/region.h"   /* Provides: REGION manipulation functions  */
 #include "player/clip.h"     /* Provides: clip function                  */
@@ -42,7 +43,6 @@
 #include "player/defaults.h" /* Provides: default settings               */
 #include "player/record.h"   /* Provides: parameter mechanism            */
 #include "player/meta.h"     /* Provides: record interpreters            */
-#include <stdint.h>
 
 /**
  * @internal


### PR DESCRIPTION
Libwmf no longer compiles due to a missing (or improperly positioned) inclusion of <stdint.h>. This fixes that.